### PR TITLE
fix: Support Chrome 41 for Google WRS

### DIFF
--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -12,7 +12,7 @@ const browserlist = [
   '>= 1%',
   'last 1 major version',
   'not dead',
-  'Chrome >= 45',
+  'Chrome >= 41',
   'Firefox >= 38',
   'Edge >= 12',
   'Explorer >= 10',


### PR DESCRIPTION
Fixes https://github.com/react-bootstrap/react-bootstrap/issues/3620.